### PR TITLE
Some code cleanup

### DIFF
--- a/src/BigFish/PaymentGateway.php
+++ b/src/BigFish/PaymentGateway.php
@@ -253,276 +253,297 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		}
 		throw new Exception('Payment Gateway configuration has not been set');
 	}
-	
-	/**
-	 * Transaction initialization
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Init $request Init request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Transaction initialization
+     *
+     * @param \BigFish\PaymentGateway\Request\Init $request Init request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function init(InitRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INIT, $request);
 	}
 
-	/**
-	 * Start payment process, redirects the user to Payment Gateway
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Start $request Start request object
-	 * @return void
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Start payment process, redirects the user to Payment Gateway
+     *
+     * @param \BigFish\PaymentGateway\Request\Start $request Start request object
+     * @return void
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function start(StartRequest $request)
 	{
 		header('Location: ' . self::getStartUrl($request));
 		exit();
 	}
-	
-	/**
-	 * Get payment start URL
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Start $request Start request object
-	 * @return string
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Get payment start URL
+     *
+     * @param \BigFish\PaymentGateway\Request\Start $request Start request object
+     * @return string
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function getStartUrl(StartRequest $request)
 	{
 		return self::getUrl() . '/Start?' . $request->getParams();
 	}
-	
-	/**
-	 * Query transaction results from Payment Gateway
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Result $request Result request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Query transaction results from Payment Gateway
+     *
+     * @param \BigFish\PaymentGateway\Request\Result $request Result request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function result(ResultRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_RESULT, $request);
 	}
 
-	/**
-	 * Close a previously started transaction
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Close $request Close request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Close a previously started transaction
+     *
+     * @param \BigFish\PaymentGateway\Request\Close $request Close request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function close(CloseRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_CLOSE, $request);
 	}
 
-	/**
-	 * Refund a transaction
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Refund $request Refund request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Refund a transaction
+     *
+     * @param \BigFish\PaymentGateway\Request\Refund $request Refund request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function refund(RefundRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_REFUND, $request);
-	}	
+	}
 
-	/**
-	 * Recurring payment transaction initialization
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\InitRP $request Recurring payment init request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Recurring payment transaction initialization
+     *
+     * @param \BigFish\PaymentGateway\Request\InitRP $request Recurring payment init request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function initRP(InitRPRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INIT_RP, $request);
 	}
-	
-	/**
-	 * Start recurring payment transaction
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\StartRP $request Recurring payment start request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Start recurring payment transaction
+     *
+     * @param \BigFish\PaymentGateway\Request\StartRP $request Recurring payment start request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function startRP(StartRPRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_START_RP, $request);
 	}
 
-	/**
-	 * Finalize a transaction
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
-	 * @return void
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Finalize a transaction
+     *
+     * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
+     * @return void
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function finalize(FinalizeRequest $request)
 	{
 		header('Location: ' . self::getFinalizeUrl($request));
 		exit();
 	}
-	
-	/**
-	 * Get payment finalize URL
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
-	 * @return string
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Get payment finalize URL
+     *
+     * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
+     * @return string
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function getFinalizeUrl(FinalizeRequest $request)
 	{
 		return self::getUrl() . '/Finalize?' . $request->getParams();
 	}
-	
-	/**
-	 * Get one click payment options
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\OneClickOptions $request
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Get one click payment options
+     *
+     * @param \BigFish\PaymentGateway\Request\OneClickOptions $request
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function oneClickOptions(OneClickOptionsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_OPTIONS, $request);
 	}
 
-	/**
-	 * One Click Token Cancel
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\OneClickTokenCancel $request OneClickTokenCancel request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * One Click Token Cancel
+     *
+     * @param \BigFish\PaymentGateway\Request\OneClickTokenCancel $request OneClickTokenCancel request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function oneClickTokenCancel(OneClickTokenCancelRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_TOKEN_CANCEL, $request);
 	}
 
-	/**
-	 * One Click Token Cancel All
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\OneClickTokenCancelAll $request OneClickTokenCancelAll request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * One Click Token Cancel All
+     *
+     * @param \BigFish\PaymentGateway\Request\OneClickTokenCancelAll $request OneClickTokenCancelAll request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function oneClickTokenCancelAll(OneClickTokenCancelAllRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_TOKEN_CANCEL_ALL, $request);
 	}
 
-	/**
-	 * Get invoice
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Invoice $request
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Get invoice
+     *
+     * @param \BigFish\PaymentGateway\Request\Invoice $request
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function invoice(InvoiceRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INVOICE, $request);
 	}
-	
-	/**
-	 * Get providers
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Providers $request
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Get providers
+     *
+     * @param \BigFish\PaymentGateway\Request\Providers $request
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function providers(ProvidersRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PROVIDERS, $request);
 	}
 
-	/**
-	 * Query transaction details from Payment Gateway
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Details $request Details request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Query transaction details from Payment Gateway
+     *
+     * @param \BigFish\PaymentGateway\Request\Details $request Details request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function details(DetailsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_DETAILS, $request);
 	}
 
-	/**
-	 * Payment link create
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\PaymentLinkCreate $request Payment link create request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Payment link create
+     *
+     * @param \BigFish\PaymentGateway\Request\PaymentLinkCreate $request Payment link create request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function paymentLinkCreate(PaymentLinkCreateRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_CREATE, $request);
 	}
 
-	/**
-	 * Payment link cancel
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\PaymentLinkCancel $request Payment link cancel request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Payment link cancel
+     *
+     * @param \BigFish\PaymentGateway\Request\PaymentLinkCancel $request Payment link cancel request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function paymentLinkCancel(PaymentLinkCancelRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_CANCEL, $request);
 	}
 
-	/**
-	 * Payment link details
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\PaymentLinkDetails $request Payment link details request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Payment link details
+     *
+     * @param \BigFish\PaymentGateway\Request\PaymentLinkDetails $request Payment link details request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function paymentLinkDetails(PaymentLinkDetailsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_DETAILS, $request);
 	}
 
-	/**
-	 * Query transaction log from Payment Gateway
-	 * 
-	 * @param \BigFish\PaymentGateway\Request\Log $request Log request object
-	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-	 * @access public
-	 * @static
-	 */
+    /**
+     * Query transaction log from Payment Gateway
+     *
+     * @param \BigFish\PaymentGateway\Request\Log $request Log request object
+     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public static function log(LogRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_LOG, $request);
 	}
-	
-	/**
-	 * Get service URL
-	 * 
-	 * @return string
-	 * @access public
-	 * @static
-	 */
+
+    /**
+     * Get service URL
+     *
+     * @return string
+     * @access public
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	protected static function getUrl()
 	{
 		if (self::getConfig()->testMode === true) {
@@ -688,15 +709,16 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		return new Response($httpResponse);
 	}
 
-	/**
-	 * Prepare request
-	 * 
-	 * @param string $method
-	 * @param \BigFish\PaymentGateway\Request\RequestAbstract $request
-	 * @return void
-	 * @access private
-	 * @static
-	 */
+    /**
+     * Prepare request
+     *
+     * @param string $method
+     * @param \BigFish\PaymentGateway\Request\RequestAbstract $request
+     * @return void
+     * @access private
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	private static function prepareRequest($method, Request $request)
 	{
 		$request->encodeValues();
@@ -711,26 +733,28 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		}
 	}
 
-	/**
-	 * Get authorization header
-	 * 
-	 * @return string
-	 * @access private
-	 * @static
-	 */
+    /**
+     * Get authorization header
+     *
+     * @return string
+     * @access private
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	private static function getAuthorizationHeader()
 	{
 		return 'Authorization: Basic ' . base64_encode(self::getConfig()->storeName . ':' . self::getConfig()->apiKey);
 	}
 
-	/**
-	 * Get user agent string
-	 * 
-	 * @param string $method
-	 * @return string
-	 * @access private
-	 * @static
-	 */
+    /**
+     * Get user agent string
+     *
+     * @param string $method
+     * @return string
+     * @access private
+     * @static
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	private static function getUserAgent($method)
 	{
 		switch (self::getConfig()->useApi) {

--- a/src/BigFish/PaymentGateway.php
+++ b/src/BigFish/PaymentGateway.php
@@ -254,296 +254,296 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		throw new Exception('Payment Gateway configuration has not been set');
 	}
 
-    /**
-     * Transaction initialization
-     *
-     * @param \BigFish\PaymentGateway\Request\Init $request Init request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Transaction initialization
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Init $request Init request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function init(InitRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INIT, $request);
 	}
 
-    /**
-     * Start payment process, redirects the user to Payment Gateway
-     *
-     * @param \BigFish\PaymentGateway\Request\Start $request Start request object
-     * @return void
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Start payment process, redirects the user to Payment Gateway
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Start $request Start request object
+	 * @return void
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function start(StartRequest $request)
 	{
 		header('Location: ' . self::getStartUrl($request));
 		exit();
 	}
 
-    /**
-     * Get payment start URL
-     *
-     * @param \BigFish\PaymentGateway\Request\Start $request Start request object
-     * @return string
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get payment start URL
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Start $request Start request object
+	 * @return string
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function getStartUrl(StartRequest $request)
 	{
 		return self::getUrl() . '/Start?' . $request->getParams();
 	}
 
-    /**
-     * Query transaction results from Payment Gateway
-     *
-     * @param \BigFish\PaymentGateway\Request\Result $request Result request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Query transaction results from Payment Gateway
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Result $request Result request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function result(ResultRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_RESULT, $request);
 	}
 
-    /**
-     * Close a previously started transaction
-     *
-     * @param \BigFish\PaymentGateway\Request\Close $request Close request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Close a previously started transaction
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Close $request Close request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function close(CloseRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_CLOSE, $request);
 	}
 
-    /**
-     * Refund a transaction
-     *
-     * @param \BigFish\PaymentGateway\Request\Refund $request Refund request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Refund a transaction
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Refund $request Refund request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function refund(RefundRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_REFUND, $request);
 	}
 
-    /**
-     * Recurring payment transaction initialization
-     *
-     * @param \BigFish\PaymentGateway\Request\InitRP $request Recurring payment init request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Recurring payment transaction initialization
+	 *
+	 * @param \BigFish\PaymentGateway\Request\InitRP $request Recurring payment init request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function initRP(InitRPRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INIT_RP, $request);
 	}
 
-    /**
-     * Start recurring payment transaction
-     *
-     * @param \BigFish\PaymentGateway\Request\StartRP $request Recurring payment start request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Start recurring payment transaction
+	 *
+	 * @param \BigFish\PaymentGateway\Request\StartRP $request Recurring payment start request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function startRP(StartRPRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_START_RP, $request);
 	}
 
-    /**
-     * Finalize a transaction
-     *
-     * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
-     * @return void
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Finalize a transaction
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
+	 * @return void
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function finalize(FinalizeRequest $request)
 	{
 		header('Location: ' . self::getFinalizeUrl($request));
 		exit();
 	}
 
-    /**
-     * Get payment finalize URL
-     *
-     * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
-     * @return string
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get payment finalize URL
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Finalize $request Finalize request object
+	 * @return string
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function getFinalizeUrl(FinalizeRequest $request)
 	{
 		return self::getUrl() . '/Finalize?' . $request->getParams();
 	}
 
-    /**
-     * Get one click payment options
-     *
-     * @param \BigFish\PaymentGateway\Request\OneClickOptions $request
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get one click payment options
+	 *
+	 * @param \BigFish\PaymentGateway\Request\OneClickOptions $request
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function oneClickOptions(OneClickOptionsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_OPTIONS, $request);
 	}
 
-    /**
-     * One Click Token Cancel
-     *
-     * @param \BigFish\PaymentGateway\Request\OneClickTokenCancel $request OneClickTokenCancel request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * One Click Token Cancel
+	 *
+	 * @param \BigFish\PaymentGateway\Request\OneClickTokenCancel $request OneClickTokenCancel request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function oneClickTokenCancel(OneClickTokenCancelRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_TOKEN_CANCEL, $request);
 	}
 
-    /**
-     * One Click Token Cancel All
-     *
-     * @param \BigFish\PaymentGateway\Request\OneClickTokenCancelAll $request OneClickTokenCancelAll request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * One Click Token Cancel All
+	 *
+	 * @param \BigFish\PaymentGateway\Request\OneClickTokenCancelAll $request OneClickTokenCancelAll request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function oneClickTokenCancelAll(OneClickTokenCancelAllRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_ONE_CLICK_TOKEN_CANCEL_ALL, $request);
 	}
 
-    /**
-     * Get invoice
-     *
-     * @param \BigFish\PaymentGateway\Request\Invoice $request
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get invoice
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Invoice $request
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function invoice(InvoiceRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_INVOICE, $request);
 	}
 
-    /**
-     * Get providers
-     *
-     * @param \BigFish\PaymentGateway\Request\Providers $request
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get providers
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Providers $request
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function providers(ProvidersRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PROVIDERS, $request);
 	}
 
-    /**
-     * Query transaction details from Payment Gateway
-     *
-     * @param \BigFish\PaymentGateway\Request\Details $request Details request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Query transaction details from Payment Gateway
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Details $request Details request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function details(DetailsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_DETAILS, $request);
 	}
 
-    /**
-     * Payment link create
-     *
-     * @param \BigFish\PaymentGateway\Request\PaymentLinkCreate $request Payment link create request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Payment link create
+	 *
+	 * @param \BigFish\PaymentGateway\Request\PaymentLinkCreate $request Payment link create request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function paymentLinkCreate(PaymentLinkCreateRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_CREATE, $request);
 	}
 
-    /**
-     * Payment link cancel
-     *
-     * @param \BigFish\PaymentGateway\Request\PaymentLinkCancel $request Payment link cancel request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Payment link cancel
+	 *
+	 * @param \BigFish\PaymentGateway\Request\PaymentLinkCancel $request Payment link cancel request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function paymentLinkCancel(PaymentLinkCancelRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_CANCEL, $request);
 	}
 
-    /**
-     * Payment link details
-     *
-     * @param \BigFish\PaymentGateway\Request\PaymentLinkDetails $request Payment link details request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Payment link details
+	 *
+	 * @param \BigFish\PaymentGateway\Request\PaymentLinkDetails $request Payment link details request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function paymentLinkDetails(PaymentLinkDetailsRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_PAYMENT_LINK_DETAILS, $request);
 	}
 
-    /**
-     * Query transaction log from Payment Gateway
-     *
-     * @param \BigFish\PaymentGateway\Request\Log $request Log request object
-     * @return \BigFish\PaymentGateway\Response Payment Gateway response object
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Query transaction log from Payment Gateway
+	 *
+	 * @param \BigFish\PaymentGateway\Request\Log $request Log request object
+	 * @return \BigFish\PaymentGateway\Response Payment Gateway response object
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public static function log(LogRequest $request)
 	{
 		return self::sendRequest(self::REQUEST_LOG, $request);
 	}
 
-    /**
-     * Get service URL
-     *
-     * @return string
-     * @access public
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get service URL
+	 *
+	 * @return string
+	 * @access public
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	protected static function getUrl()
 	{
 		if (self::getConfig()->testMode === true) {
@@ -709,16 +709,16 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		return new Response($httpResponse);
 	}
 
-    /**
-     * Prepare request
-     *
-     * @param string $method
-     * @param \BigFish\PaymentGateway\Request\RequestAbstract $request
-     * @return void
-     * @access private
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Prepare request
+	 *
+	 * @param string $method
+	 * @param \BigFish\PaymentGateway\Request\RequestAbstract $request
+	 * @return void
+	 * @access private
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	private static function prepareRequest($method, Request $request)
 	{
 		$request->encodeValues();
@@ -733,28 +733,28 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		}
 	}
 
-    /**
-     * Get authorization header
-     *
-     * @return string
-     * @access private
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get authorization header
+	 *
+	 * @return string
+	 * @access private
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	private static function getAuthorizationHeader()
 	{
 		return 'Authorization: Basic ' . base64_encode(self::getConfig()->storeName . ':' . self::getConfig()->apiKey);
 	}
 
-    /**
-     * Get user agent string
-     *
-     * @param string $method
-     * @return string
-     * @access private
-     * @static
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get user agent string
+	 *
+	 * @param string $method
+	 * @return string
+	 * @access private
+	 * @static
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	private static function getUserAgent($method)
 	{
 		switch (self::getConfig()->useApi) {
@@ -764,8 +764,8 @@ XIm63iVw6gjP2qDnNwIDAQAB
 			case self::API_REST:
 				$clientType = 'Rest';
 				break;
-            default:
-                throw new Exception('No API type defined!');
+			default:
+				throw new Exception('No API type defined!');
 		}
 
 		return sprintf('BIG FISH Payment Gateway %s Client v%s (%s - %s)', $clientType, self::VERSION, $method, self::getHttpHost());

--- a/src/BigFish/PaymentGateway.php
+++ b/src/BigFish/PaymentGateway.php
@@ -764,6 +764,8 @@ XIm63iVw6gjP2qDnNwIDAQAB
 			case self::API_REST:
 				$clientType = 'Rest';
 				break;
+            default:
+                throw new Exception('No API type defined!');
 		}
 
 		return sprintf('BIG FISH Payment Gateway %s Client v%s (%s - %s)', $clientType, self::VERSION, $method, self::getHttpHost());

--- a/src/BigFish/PaymentGateway/Autoload.php
+++ b/src/BigFish/PaymentGateway/Autoload.php
@@ -18,7 +18,7 @@ class Autoload
 	/**
 	 * Autoloader instance
 	 * 
-	 * @var BigFish\PaymentGateway\Autoload
+	 * @var \BigFish\PaymentGateway\Autoload
 	 * @access private
 	 * @static
 	 */
@@ -66,7 +66,7 @@ class Autoload
 	/**
 	 * Get autoloader instance
 	 * 
-	 * @return BigFish\PaymentGateway\Autoload
+	 * @return \BigFish\PaymentGateway\Autoload
 	 * @access private
 	 * @static
 	 */

--- a/src/BigFish/PaymentGateway/Config.php
+++ b/src/BigFish/PaymentGateway/Config.php
@@ -105,7 +105,7 @@ class Config
 	protected $gatewayUrlTest = PaymentGateway::GATEWAY_URL_TEST;
 
 	/**
-	 * Contructor
+	 * Constructor
 	 * 
 	 * @param array $config
 	 * @access public

--- a/src/BigFish/PaymentGateway/Request/Close.php
+++ b/src/BigFish/PaymentGateway/Request/Close.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Close request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Details.php
+++ b/src/BigFish/PaymentGateway/Request/Details.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Details request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Finalize.php
+++ b/src/BigFish/PaymentGateway/Request/Finalize.php
@@ -46,13 +46,13 @@ class Finalize extends RequestAbstract
 		$this->amount = (float)$amount;
 	}
 
-    /**
-     * Get object parameters
-     *
-     * @return string
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get object parameters
+	 * 
+	 * @return string
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function getParams()
 	{
 		unset($this->responseMode);

--- a/src/BigFish/PaymentGateway/Request/Finalize.php
+++ b/src/BigFish/PaymentGateway/Request/Finalize.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Finalize request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Finalize.php
+++ b/src/BigFish/PaymentGateway/Request/Finalize.php
@@ -45,13 +45,14 @@ class Finalize extends RequestAbstract
 		$this->transactionId = $transactionId;
 		$this->amount = (float)$amount;
 	}
-	
-	/**
-	 * Get object parameters
-	 * 
-	 * @return string
-	 * @access public
-	 */
+
+    /**
+     * Get object parameters
+     *
+     * @return string
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function getParams()
 	{
 		unset($this->responseMode);

--- a/src/BigFish/PaymentGateway/Request/Init.php
+++ b/src/BigFish/PaymentGateway/Request/Init.php
@@ -240,6 +240,7 @@ class Init extends RequestAbstract
 	 * Construct new Init request instance
 	 * 
 	 * @access public
+     * @throws \BigFish\PaymentGateway\Exception
 	 */
 	public function __construct()
 	{

--- a/src/BigFish/PaymentGateway/Request/Init.php
+++ b/src/BigFish/PaymentGateway/Request/Init.php
@@ -240,7 +240,7 @@ class Init extends RequestAbstract
 	 * Construct new Init request instance
 	 * 
 	 * @access public
-     * @throws \BigFish\PaymentGateway\Exception
+	 * @throws \BigFish\PaymentGateway\Exception
 	 */
 	public function __construct()
 	{
@@ -649,13 +649,13 @@ class Init extends RequestAbstract
 		$this->extra = $this->urlSafeEncode($encrypted);
 	}
 
-    /**
-     * Get object parameters
-     *
-     * @return string
-     * @access public
-     * @throws Exception
-     */
+	/**
+	 * Get object parameters
+	 * 
+	 * @return string
+	 * @access public
+	 * @throws Exception
+	 */
 	public function getParams()
 	{
 		$this->setExtra();

--- a/src/BigFish/PaymentGateway/Request/Init.php
+++ b/src/BigFish/PaymentGateway/Request/Init.php
@@ -647,13 +647,14 @@ class Init extends RequestAbstract
 
 		$this->extra = $this->urlSafeEncode($encrypted);
 	}
-	
-	/**
-	 * Get object parameters
-	 * 
-	 * @return string
-	 * @access public
-	 */
+
+    /**
+     * Get object parameters
+     *
+     * @return string
+     * @access public
+     * @throws Exception
+     */
 	public function getParams()
 	{
 		$this->setExtra();

--- a/src/BigFish/PaymentGateway/Request/InitRP.php
+++ b/src/BigFish/PaymentGateway/Request/InitRP.php
@@ -90,11 +90,12 @@ class InitRP extends RequestAbstract
 	 */
 	public $moduleVersion;
 
-	/**
-	 * Construct new recurring payment Init request instance
-	 * 
-	 * @access public
-	 */
+    /**
+     * Construct new recurring payment Init request instance
+     *
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/InitRP.php
+++ b/src/BigFish/PaymentGateway/Request/InitRP.php
@@ -12,7 +12,7 @@ use BigFish\PaymentGateway;
 
 /**
  * Recurring payment initialization request class
- *
+ * 
  * @package PaymentGateway
  * @subpackage Request
  */
@@ -66,21 +66,21 @@ class InitRP extends RequestAbstract
 	 */
 	public $currency;
 
-    /**
-     * Store name
-     *
-     * @var string
-     * @access public
-     */
-    public $storeName;
+	/**
+	 * Store name
+	 * 
+	 * @var string
+	 * @access public
+	 */
+	public $storeName;
 
-    /**
-     * Module name
-     *
-     * @var string
-     * @access public
-     */
-    public $moduleName;
+	/**
+	 * Module name
+	 *
+	 * @var string
+	 * @access public
+	 */
+	public $moduleName;
 
 	/**
 	 * Module version
@@ -90,12 +90,12 @@ class InitRP extends RequestAbstract
 	 */
 	public $moduleVersion;
 
-    /**
-     * Construct new recurring payment Init request instance
-     *
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Construct new recurring payment Init request instance
+	 *
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/InitRP.php
+++ b/src/BigFish/PaymentGateway/Request/InitRP.php
@@ -12,7 +12,7 @@ use BigFish\PaymentGateway;
 
 /**
  * Recurring payment initialization request class
- * 
+ *
  * @package PaymentGateway
  * @subpackage Request
  */
@@ -66,13 +66,21 @@ class InitRP extends RequestAbstract
 	 */
 	public $currency;
 
-	/**
-	 * Module name
-	 *
-	 * @var string
-	 * @access public
-	 */
-	public $moduleName;
+    /**
+     * Store name
+     *
+     * @var string
+     * @access public
+     */
+    public $storeName;
+
+    /**
+     * Module name
+     *
+     * @var string
+     * @access public
+     */
+    public $moduleName;
 
 	/**
 	 * Module version

--- a/src/BigFish/PaymentGateway/Request/Invoice.php
+++ b/src/BigFish/PaymentGateway/Request/Invoice.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Invoice request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Log.php
+++ b/src/BigFish/PaymentGateway/Request/Log.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Log request class
  * 

--- a/src/BigFish/PaymentGateway/Request/OneClickOptions.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickOptions.php
@@ -42,14 +42,15 @@ class OneClickOptions extends RequestAbstract
 	 */
 	public $userId;
 
-	/**
-	 * Construct new One Click Options request instance
-	 * 
-	 * @param string $providerName Provider name
-	 * @param string $userId User identifier
-	 * @return void
-	 * @access public
-	 */
+    /**
+     * Construct new One Click Options request instance
+     *
+     * @param string $providerName Provider name
+     * @param string $userId User identifier
+     * @throws \BigFish\PaymentGateway\Exception
+     * @return void
+     * @access public
+     */
 	public function __construct($providerName, $userId)
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/OneClickOptions.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickOptions.php
@@ -42,15 +42,15 @@ class OneClickOptions extends RequestAbstract
 	 */
 	public $userId;
 
-    /**
-     * Construct new One Click Options request instance
-     *
-     * @param string $providerName Provider name
-     * @param string $userId User identifier
-     * @throws \BigFish\PaymentGateway\Exception
-     * @return void
-     * @access public
-     */
+	/**
+	 * Construct new One Click Options request instance
+	 *
+	 * @param string $providerName Provider name
+	 * @param string $userId User identifier
+	 * @throws \BigFish\PaymentGateway\Exception
+	 * @return void
+	 * @access public
+	 */
 	public function __construct($providerName, $userId)
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/OneClickOptions.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickOptions.php
@@ -8,7 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
 use BigFish\PaymentGateway;
 
 /**

--- a/src/BigFish/PaymentGateway/Request/OneClickTokenCancel.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickTokenCancel.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * One Click Token Cancel request class
  * 

--- a/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
@@ -42,14 +42,15 @@ class OneClickTokenCancelAll extends RequestAbstract
 	 */
 	public $userId;
 
-	/**
-	 * Construct new One Click Token Cancel All request instance
-	 * 
-	 * @param $string $providerName
-	 * @param $string $userId
-	 * @return void
-	 * @access public
-	 */
+    /**
+     * Construct new One Click Token Cancel All request instance
+     *
+     * @param string $providerName
+     * @param string $userId
+     * @throws \BigFish\PaymentGateway\Exception
+     * @return void
+     * @access public
+     */
 	public function __construct($providerName, $userId)
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
@@ -42,15 +42,15 @@ class OneClickTokenCancelAll extends RequestAbstract
 	 */
 	public $userId;
 
-    /**
-     * Construct new One Click Token Cancel All request instance
-     *
-     * @param string $providerName
-     * @param string $userId
-     * @throws \BigFish\PaymentGateway\Exception
-     * @return void
-     * @access public
-     */
+	/**
+	 * Construct new One Click Token Cancel All request instance
+	 *
+	 * @param string $providerName
+	 * @param string $userId
+	 * @throws \BigFish\PaymentGateway\Exception
+	 * @return void
+	 * @access public
+	 */
 	public function __construct($providerName, $userId)
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
+++ b/src/BigFish/PaymentGateway/Request/OneClickTokenCancelAll.php
@@ -9,7 +9,6 @@
 namespace BigFish\PaymentGateway\Request;
 
 use BigFish\PaymentGateway;
-use BigFish\PaymentGateway\Request\RequestAbstract;
 
 /**
  * One Click Token Cancel All request class

--- a/src/BigFish/PaymentGateway/Request/PaymentLinkCancel.php
+++ b/src/BigFish/PaymentGateway/Request/PaymentLinkCancel.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway;
-
 /**
  * Payment link cancel request class
  * 

--- a/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
+++ b/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
@@ -138,11 +138,12 @@ class PaymentLinkCreate extends RequestAbstract
 	 */
 	public $moduleVersion;
 
-	/**
-	 * Construct payment link create request instance
-	 * 
-	 * @access public
-	 */
+    /**
+     * Construct payment link create request instance
+     *
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
+++ b/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
@@ -138,12 +138,12 @@ class PaymentLinkCreate extends RequestAbstract
 	 */
 	public $moduleVersion;
 
-    /**
-     * Construct payment link create request instance
-     *
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Construct payment link create request instance
+	 *
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
+++ b/src/BigFish/PaymentGateway/Request/PaymentLinkCreate.php
@@ -300,7 +300,6 @@ class PaymentLinkCreate extends RequestAbstract
 	 * @param array $extra Extra information
 	 * @return \BigFish\PaymentGateway\Request\PaymentLinkCreate
 	 * @access public
-	 * @throws Exception
 	 */
 	public function setExtra(array $extra = array())
 	{

--- a/src/BigFish/PaymentGateway/Request/PaymentLinkDetails.php
+++ b/src/BigFish/PaymentGateway/Request/PaymentLinkDetails.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway;
-
 /**
  * Payment link details request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Providers.php
+++ b/src/BigFish/PaymentGateway/Request/Providers.php
@@ -8,7 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
 use BigFish\PaymentGateway;
 
 /**

--- a/src/BigFish/PaymentGateway/Request/Providers.php
+++ b/src/BigFish/PaymentGateway/Request/Providers.php
@@ -26,12 +26,13 @@ class Providers extends RequestAbstract
 	 */
 	public $storeName;
 
-	/**
-	 * Construct new Providers request instance
-	 * 
-	 * @return void
-	 * @access public
-	 */
+    /**
+     * Construct new Providers request instance
+     *
+     * @throws \BigFish\PaymentGateway\Exception
+     * @return void
+     * @access public
+     */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/Providers.php
+++ b/src/BigFish/PaymentGateway/Request/Providers.php
@@ -26,13 +26,13 @@ class Providers extends RequestAbstract
 	 */
 	public $storeName;
 
-    /**
-     * Construct new Providers request instance
-     *
-     * @throws \BigFish\PaymentGateway\Exception
-     * @return void
-     * @access public
-     */
+	/**
+	 * Construct new Providers request instance
+	 *
+	 * @throws \BigFish\PaymentGateway\Exception
+	 * @return void
+	 * @access public
+	 */
 	public function __construct()
 	{
 		$this->storeName = PaymentGateway::getConfig()->storeName;

--- a/src/BigFish/PaymentGateway/Request/Refund.php
+++ b/src/BigFish/PaymentGateway/Request/Refund.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Refund request class
  * 

--- a/src/BigFish/PaymentGateway/Request/RequestAbstract.php
+++ b/src/BigFish/PaymentGateway/Request/RequestAbstract.php
@@ -19,16 +19,16 @@ use BigFish\PaymentGateway;
  */
 abstract class RequestAbstract
 {
-    /**
-     * Construct query string from object properties
-     *
-     * @return string Constructed query string
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Construct query string from object properties
+	 *
+	 * @return string Constructed query string
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function getParams()
 	{
-        $params = array();
+		$params = array();
 		foreach ($this as $name => $value) {
 			$value = trim($value);
 
@@ -39,14 +39,14 @@ abstract class RequestAbstract
 		return implode("&", $params);
 	}
 
-    /**
-     * Encode value
-     *
-     * @param string $value
-     * @return string
-     * @access protected
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Encode value
+	 *
+	 * @param string $value
+	 * @return string
+	 * @access protected
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	protected function encodeValue($value)
 	{
 		if (
@@ -60,13 +60,13 @@ abstract class RequestAbstract
 		return $value;
 	}
 
-    /**
-     * Encode object parameter values
-     *
-     * @return void
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Encode object parameter values
+	 *
+	 * @return void
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function encodeValues()
 	{
 		foreach (get_object_vars($this) as $key => $value) {

--- a/src/BigFish/PaymentGateway/Request/RequestAbstract.php
+++ b/src/BigFish/PaymentGateway/Request/RequestAbstract.php
@@ -19,12 +19,13 @@ use BigFish\PaymentGateway;
  */
 abstract class RequestAbstract
 {
-	/**
-	 * Construct query string from object properties
-	 * 
-	 * @return string Constructed query string
-	 * @access public
-	 */
+    /**
+     * Construct query string from object properties
+     *
+     * @return string Constructed query string
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function getParams()
 	{
 		foreach ($this as $name => $value) {
@@ -37,13 +38,14 @@ abstract class RequestAbstract
 		return implode("&", $params);
 	}
 
-	/**
-	 * Encode value
-	 * 
-	 * @param string $value
-	 * @return string
-	 * @access protected
-	 */
+    /**
+     * Encode value
+     *
+     * @param string $value
+     * @return string
+     * @access protected
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	protected function encodeValue($value)
 	{
 		if (
@@ -57,12 +59,13 @@ abstract class RequestAbstract
 		return $value;
 	}
 
-	/**
-	 * Encode object parameter values
-	 * 
-	 * @return void
-	 * @access public
-	 */
+    /**
+     * Encode object parameter values
+     *
+     * @return void
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function encodeValues()
 	{
 		foreach (get_object_vars($this) as $key => $value) {

--- a/src/BigFish/PaymentGateway/Request/RequestAbstract.php
+++ b/src/BigFish/PaymentGateway/Request/RequestAbstract.php
@@ -28,6 +28,7 @@ abstract class RequestAbstract
      */
 	public function getParams()
 	{
+        $params = array();
 		foreach ($this as $name => $value) {
 			$value = trim($value);
 

--- a/src/BigFish/PaymentGateway/Request/Result.php
+++ b/src/BigFish/PaymentGateway/Request/Result.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Result request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Start.php
+++ b/src/BigFish/PaymentGateway/Request/Start.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Start request class
  * 

--- a/src/BigFish/PaymentGateway/Request/Start.php
+++ b/src/BigFish/PaymentGateway/Request/Start.php
@@ -36,12 +36,13 @@ class Start extends RequestAbstract
 		$this->transactionId = $transactionId;
 	}
 
-	/**
-	 * Get object parameters
-	 * 
-	 * @return string
-	 * @access public
-	 */
+    /**
+     * Get object parameters
+     *
+     * @return string
+     * @access public
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	public function getParams()
 	{
 		unset($this->responseMode);

--- a/src/BigFish/PaymentGateway/Request/Start.php
+++ b/src/BigFish/PaymentGateway/Request/Start.php
@@ -36,13 +36,13 @@ class Start extends RequestAbstract
 		$this->transactionId = $transactionId;
 	}
 
-    /**
-     * Get object parameters
-     *
-     * @return string
-     * @access public
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Get object parameters
+	 *
+	 * @return string
+	 * @access public
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	public function getParams()
 	{
 		unset($this->responseMode);

--- a/src/BigFish/PaymentGateway/Request/StartRP.php
+++ b/src/BigFish/PaymentGateway/Request/StartRP.php
@@ -8,8 +8,6 @@
  */
 namespace BigFish\PaymentGateway\Request;
 
-use BigFish\PaymentGateway\Request\RequestAbstract;
-
 /**
  * Recurring payment start request class
  * 

--- a/src/BigFish/PaymentGateway/Response.php
+++ b/src/BigFish/PaymentGateway/Response.php
@@ -17,13 +17,14 @@ use BigFish\PaymentGateway;
  */
 class Response
 {
-	/**
-	 * Construct new response object from JSON encoded object
-	 * 
-	 * @param string $json JSON encoded object
-	 * @return void
-	 * @access public
-	 */
+    /**
+     * Construct new response object from JSON encoded object
+     *
+     * @param string $json JSON encoded object
+     * @throws \BigFish\PaymentGateway\Exception
+     * @return void
+     * @access public
+     */
 	public function __construct($json)
 	{
 		if (is_object($json)) {
@@ -37,13 +38,14 @@ class Response
 		}
 	}
 
-	/**
-	 * Set object
-	 * 
-	 * @param object $object
-	 * @return void
-	 * @access protected
-	 */
+    /**
+     * Set object
+     *
+     * @param object $object
+     * @return void
+     * @access protected
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	protected function setObject($object)
 	{
 		foreach (get_object_vars($object) as $name => $value) {
@@ -59,14 +61,15 @@ class Response
 		}
 	}
 
-	/**
-	 * Set value
-	 * 
-	 * @param string $name
-	 * @param string $value
-	 * @return void
-	 * @access protected
-	 */
+    /**
+     * Set value
+     *
+     * @param string $name
+     * @param string $value
+     * @return void
+     * @access protected
+     * @throws \BigFish\PaymentGateway\Exception
+     */
 	protected function setValue($name, $value)
 	{
 		if (is_string($value) && PaymentGateway::getConfig()->outCharset != "UTF-8") {

--- a/src/BigFish/PaymentGateway/Response.php
+++ b/src/BigFish/PaymentGateway/Response.php
@@ -17,14 +17,14 @@ use BigFish\PaymentGateway;
  */
 class Response
 {
-    /**
-     * Construct new response object from JSON encoded object
-     *
-     * @param string $json JSON encoded object
-     * @throws \BigFish\PaymentGateway\Exception
-     * @return void
-     * @access public
-     */
+	/**
+	 * Construct new response object from JSON encoded object
+	 *
+	 * @param string $json JSON encoded object
+	 * @throws \BigFish\PaymentGateway\Exception
+	 * @return void
+	 * @access public
+	 */
 	public function __construct($json)
 	{
 		if (is_object($json)) {
@@ -38,14 +38,14 @@ class Response
 		}
 	}
 
-    /**
-     * Set object
-     *
-     * @param object $object
-     * @return void
-     * @access protected
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Set object
+	 *
+	 * @param object $object
+	 * @return void
+	 * @access protected
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	protected function setObject($object)
 	{
 		foreach (get_object_vars($object) as $name => $value) {
@@ -61,15 +61,15 @@ class Response
 		}
 	}
 
-    /**
-     * Set value
-     *
-     * @param string $name
-     * @param string $value
-     * @return void
-     * @access protected
-     * @throws \BigFish\PaymentGateway\Exception
-     */
+	/**
+	 * Set value
+	 *
+	 * @param string $name
+	 * @param string $value
+	 * @return void
+	 * @access protected
+	 * @throws \BigFish\PaymentGateway\Exception
+	 */
 	protected function setValue($name, $value)
 	{
 		if (is_string($value) && PaymentGateway::getConfig()->outCharset != "UTF-8") {


### PR DESCRIPTION
- Remove unused/unneeded imports (No need to import from the same package)
- Fix phpDoc "undefined class" issue (If you are inside a package, you need to use \ at the begen of the imported/used full qualified package. If not, the actual package will be put to the beginning of your "classname")
- Fix a phpDoc comment (A @throws was missing)
- Add missing @throws phpDoc (And some more @throws)
- Remove unneeded @throws phpDoc, because never thrown (the method never throws any Exception)
- Add default case if there is no API type defined (If the config is wrong your $clientType variable won't be set and the sprintf() method will try to use a non existing variable, so you need to handle this case also)
- Define variable before use a non-defined variable (same reason, there is no garanty your app runs into the foreach and the if and creates a $params array variable)
- Add a field declaration to avoid dynamic initialization
- Add @throws phpDoc for the unhandled Ecxeptions (there were many methods those call something that can throw exception handle it or declare it as @throws)
- Fix a typo