### PR TITLE
add optional curl debug info to the Response

### DIFF
--- a/src/BigFish/PaymentGateway.php
+++ b/src/BigFish/PaymentGateway.php
@@ -270,6 +270,11 @@ XIm63iVw6gjP2qDnNwIDAQAB
 	protected static $config;
 
 	/**
+	 * @var bool
+	 */
+	protected static $debugCommunication = false;
+
+	/**
 	 * Set configuration
 	 * 
 	 * @param \BigFish\PaymentGateway\Config $config
@@ -303,6 +308,23 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		}
 		throw new Exception('Payment Gateway configuration has not been set');
 	}
+
+    /**
+     * @return bool
+     */
+    public static function isDebugCommunication(): bool
+    {
+        return self::$debugCommunication;
+    }
+
+    /**
+     * @param bool $debugCommunication
+     */
+    public static function setDebugCommunication(bool $debugCommunication): void
+    {
+        self::$debugCommunication = $debugCommunication;
+    }
+
 
 	/**
 	 * Transaction initialization
@@ -748,6 +770,10 @@ XIm63iVw6gjP2qDnNwIDAQAB
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
 		curl_setopt($ch, CURLOPT_USERAGENT, self::getUserAgent($method));
 
+		if (self::isDebugCommunication()) {
+			curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+		}
+
 		$httpResponse = curl_exec($ch);
 
 		if ($httpResponse === false) {
@@ -758,9 +784,17 @@ XIm63iVw6gjP2qDnNwIDAQAB
 			throw $e;
 		}
 
+		$curlRequestDump = [];
+		if (self::isDebugCommunication()) {
+			$curlRequestDump = [
+				'curl_getinfo' => curl_getinfo($ch),
+				'post_data' => $postData
+			];
+		}
+
 		curl_close($ch);
 
-		return new Response($httpResponse);
+		return new Response($httpResponse, $curlRequestDump);
 	}
 
 	/**
@@ -809,5 +843,4 @@ XIm63iVw6gjP2qDnNwIDAQAB
 
 		return 'localhost';
 	}
-
 }

--- a/src/BigFish/PaymentGateway/Response.php
+++ b/src/BigFish/PaymentGateway/Response.php
@@ -18,14 +18,21 @@ use BigFish\PaymentGateway;
 class Response
 {
 	/**
+	 * @var array
+	 */
+	public $curlRequestDump = [];
+
+	/**
 	 * Construct new response object from JSON encoded object
 	 *
 	 * @param string $json JSON encoded object
+	 * @param array $curlRequestDump
+	 *
 	 * @throws \BigFish\PaymentGateway\Exception
 	 * @return void
 	 * @access public
 	 */
-	public function __construct($json)
+	public function __construct($json, $curlRequestDump = [])
 	{
 		if (is_object($json)) {
 			$object = $json;
@@ -36,6 +43,8 @@ class Response
 		if (is_object($object)) {
 			$this->setObject($object);
 		}
+
+		$this->curlRequestDump = $curlRequestDump;
 	}
 
 	/**
@@ -78,5 +87,4 @@ class Response
 		
 		$this->{ucfirst($name)} = $value;
 	}
-
 }


### PR DESCRIPTION
This PR adds the possibility to get curl debug info using the Response object.

It is a fully backward-compatible and optional feature that we use in a forked version for years.
It would be great to see it in the upstream repo.